### PR TITLE
Add openssh-clients to gcloud_centos

### DIFF
--- a/gcloud_centos.packages
+++ b/gcloud_centos.packages
@@ -1,2 +1,3 @@
 google-cloud-sdk
+openssh-clients
 sudo


### PR DESCRIPTION
Otherwise 'gcloud ssh user@foo.bar' won't work.

Signed-off-by: Chris Evich <cevich@redhat.com>